### PR TITLE
fix: Clean up ante handler duplication and integrate WASI module

### DIFF
--- a/crates/helium-baseapp/src/ante.rs
+++ b/crates/helium-baseapp/src/ante.rs
@@ -1,11 +1,10 @@
-//! WASI Ante Handler Bridge
+//! WASI Ante Handler Adapter
 //!
-//! This module provides a bridge to the WASI-based ante handler module.
-//! Instead of hardcoded ante handlers, it dynamically loads and executes
-//! the ante handler as a WASM module following the microkernel architecture.
+//! This module provides a thin adapter to the WASI-based ante handler module.
+//! All transaction validation logic resides in the WASI module itself.
 
 use crate::wasi_host::WasiHost;
-use helium_types::{RawTx, SdkError};
+use helium_types::RawTx;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use thiserror::Error;
@@ -29,16 +28,12 @@ pub enum AnteError {
     /// Serialization error
     #[error("Serialization error: {0}")]
     SerializationError(String),
-
-    /// SDK error
-    #[error("SDK error: {0}")]
-    SdkError(#[from] SdkError),
 }
 
 /// Result type for ante handlers
 pub type AnteResult<T> = Result<T, AnteError>;
 
-/// Context for ante handler execution
+/// Context for ante handler execution - passed to WASI module
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AnteContext {
     /// Block height
@@ -47,49 +42,10 @@ pub struct AnteContext {
     pub block_time: u64,
     /// Chain ID
     pub chain_id: String,
-    /// Gas meter for tracking gas consumption
-    pub gas_used: u64,
     /// Gas limit for this transaction
     pub gas_limit: u64,
     /// Minimum gas price
     pub min_gas_price: u64,
-}
-
-impl AnteContext {
-    /// Create a new ante context
-    pub fn new(
-        block_height: u64,
-        block_time: u64,
-        chain_id: String,
-        gas_limit: u64,
-        min_gas_price: u64,
-    ) -> Self {
-        Self {
-            block_height,
-            block_time,
-            chain_id,
-            gas_used: 0,
-            gas_limit,
-            min_gas_price,
-        }
-    }
-
-    /// Consume gas and check if limit is exceeded
-    pub fn consume_gas(&mut self, amount: u64) -> AnteResult<()> {
-        self.gas_used += amount;
-        if self.gas_used > self.gas_limit {
-            return Err(AnteError::WasiError(format!(
-                "Gas limit exceeded: wanted {}, limit {}",
-                self.gas_used, self.gas_limit
-            )));
-        }
-        Ok(())
-    }
-
-    /// Get remaining gas
-    pub fn remaining_gas(&self) -> u64 {
-        self.gas_limit.saturating_sub(self.gas_used)
-    }
 }
 
 /// WASI ante handler response
@@ -128,7 +84,7 @@ pub struct TxResponse {
     pub events: Vec<WasiEvent>,
 }
 
-/// WASI-based ante handler that loads and executes WASM modules
+/// WASI-based ante handler adapter
 pub struct WasiAnteHandler {
     /// WASI host for executing modules
     wasi_host: WasiHost,
@@ -171,25 +127,18 @@ impl WasiAnteHandler {
     }
 
     /// Execute ante handler for transaction validation
-    pub fn handle(&mut self, ctx: &mut AnteContext, tx: &RawTx) -> AnteResult<TxResponse> {
+    pub fn handle(&mut self, ctx: &AnteContext, tx: &RawTx) -> AnteResult<TxResponse> {
         debug!(
             "WASI Ante Handler: Processing transaction for chain {}",
             ctx.chain_id
         );
 
-        // Convert RawTx to WASI format
-        let wasi_tx = self.convert_tx_to_wasi(tx)?;
-        let wasi_ctx = self.convert_context_to_wasi(ctx)?;
-
-        // Prepare input for WASI module
-        let input = serde_json::to_string(&(wasi_ctx, wasi_tx))
+        // Prepare input for WASI module - the module expects (context, transaction)
+        let input = serde_json::to_string(&(ctx, tx))
             .map_err(|e| AnteError::SerializationError(e.to_string()))?;
 
         // Execute the ante handler module
         let response = self.execute_ante_module("default", &input)?;
-
-        // Update context with gas used
-        ctx.gas_used += response.gas_used;
 
         // Convert response
         Ok(TxResponse {
@@ -233,156 +182,11 @@ impl WasiAnteHandler {
 
         Ok(response)
     }
-
-    fn convert_tx_to_wasi(&self, tx: &RawTx) -> AnteResult<serde_json::Value> {
-        // Convert RawTx to the WASI Transaction format
-        // This is a simplified conversion - in a real implementation,
-        // you would need proper protobuf deserialization
-
-        let wasi_tx = serde_json::json!({
-            "body": {
-                "messages": tx.body.messages.iter().map(|msg| {
-                    serde_json::json!({
-                        "type_url": msg.type_url,
-                        "value": msg.value
-                    })
-                }).collect::<Vec<_>>(),
-                "memo": tx.body.memo,
-                "timeout_height": tx.body.timeout_height
-            },
-            "auth_info": {
-                "signer_infos": tx.auth_info.signer_infos.iter().map(|si| {
-                    serde_json::json!({
-                        "public_key": si.public_key.as_ref().map(|pk| {
-                            serde_json::json!({
-                                "type_url": pk.type_url,
-                                "value": pk.value
-                            })
-                        }),
-                        "sequence": si.sequence,
-                        "mode_info": {
-                            "mode": si.mode_info.single.as_ref().map(|s| s.mode).unwrap_or(1)
-                        }
-                    })
-                }).collect::<Vec<_>>(),
-                "fee": {
-                    "amount": tx.auth_info.fee.amount.iter().map(|coin| {
-                        serde_json::json!({
-                            "denom": coin.denom,
-                            "amount": coin.amount
-                        })
-                    }).collect::<Vec<_>>(),
-                    "gas_limit": tx.auth_info.fee.gas_limit,
-                    "payer": tx.auth_info.fee.payer,
-                    "granter": tx.auth_info.fee.granter
-                }
-            },
-            "signatures": tx.signatures
-        });
-
-        Ok(wasi_tx)
-    }
-
-    fn convert_context_to_wasi(&self, ctx: &AnteContext) -> AnteResult<serde_json::Value> {
-        Ok(serde_json::json!({
-            "block_height": ctx.block_height,
-            "block_time": ctx.block_time,
-            "chain_id": ctx.chain_id,
-            "gas_limit": ctx.gas_limit,
-            "min_gas_price": ctx.min_gas_price
-        }))
-    }
-
-    /// Get gas consumption for this handler
-    pub fn gas_cost(&self) -> u64 {
-        1000 // Base gas cost for WASI module loading
-    }
 }
 
 impl Default for WasiAnteHandler {
     fn default() -> Self {
         Self::new().expect("Failed to create default WASI ante handler")
-    }
-}
-
-/// Ante handler chain for composing multiple WASI modules
-pub struct WasiAnteHandlerChain {
-    /// List of WASI ante handler modules to execute in order
-    handlers: Vec<WasiAnteHandler>,
-}
-
-impl WasiAnteHandlerChain {
-    /// Create a new ante handler chain
-    pub fn new() -> Self {
-        Self {
-            handlers: Vec::new(),
-        }
-    }
-
-    /// Add a WASI handler to the chain
-    pub fn add_handler(mut self, handler: WasiAnteHandler) -> Self {
-        self.handlers.push(handler);
-        self
-    }
-
-    /// Create a default ante handler chain with standard WASI modules
-    pub fn default_chain() -> AnteResult<Self> {
-        let mut handler = WasiAnteHandler::new()?;
-
-        // Try to load the default ante handler module
-        if let Err(e) = handler.load_module("default", "modules/ante_handler.wasm") {
-            warn!(
-                "Failed to load default ante handler module: {}. Using placeholder.",
-                e
-            );
-        }
-
-        Ok(Self::new().add_handler(handler))
-    }
-
-    /// Execute all WASI handlers in the chain
-    pub fn handle(&mut self, ctx: &mut AnteContext, tx: &RawTx) -> AnteResult<TxResponse> {
-        let mut combined_response = TxResponse {
-            code: 0,
-            log: String::new(),
-            gas_used: 0,
-            gas_wanted: ctx.gas_limit,
-            events: Vec::new(),
-        };
-
-        for handler in &mut self.handlers {
-            let response = handler.handle(ctx, tx)?;
-
-            if response.code != 0 {
-                return Ok(response); // Return first error
-            }
-
-            combined_response.gas_used += response.gas_used;
-            combined_response.events.extend(response.events);
-
-            if !response.log.is_empty() {
-                if !combined_response.log.is_empty() {
-                    combined_response.log.push_str("; ");
-                }
-                combined_response.log.push_str(&response.log);
-            }
-        }
-
-        Ok(combined_response)
-    }
-
-    /// Get total gas cost for all handlers
-    pub fn total_gas_cost(&self) -> u64 {
-        self.handlers.iter().map(|h| h.gas_cost()).sum()
-    }
-}
-
-impl Default for WasiAnteHandlerChain {
-    fn default() -> Self {
-        Self::default_chain().unwrap_or_else(|e| {
-            error!("Failed to create default WASI ante handler chain: {}", e);
-            Self::new()
-        })
     }
 }
 
@@ -393,7 +197,13 @@ mod tests {
     use helium_types::{AuthInfo, Fee, FeeAmount, SignerInfo, TxBody, TxMessage};
 
     fn create_test_context() -> AnteContext {
-        AnteContext::new(100, 1234567890, "test-chain".to_string(), 200000, 1)
+        AnteContext {
+            block_height: 100,
+            block_time: 1234567890,
+            chain_id: "test-chain".to_string(),
+            gas_limit: 200000,
+            min_gas_price: 1,
+        }
     }
 
     fn create_test_tx() -> RawTx {
@@ -433,53 +243,14 @@ mod tests {
 
     #[test]
     fn test_ante_context() {
-        let mut ctx = create_test_context();
-
+        let ctx = create_test_context();
         assert_eq!(ctx.block_height, 100);
-        assert_eq!(ctx.gas_used, 0);
-        assert_eq!(ctx.remaining_gas(), 200000);
-
-        // Test gas consumption
-        ctx.consume_gas(1000).unwrap();
-        assert_eq!(ctx.gas_used, 1000);
-        assert_eq!(ctx.remaining_gas(), 199000);
+        assert_eq!(ctx.gas_limit, 200000);
     }
 
     #[test]
     fn test_wasi_ante_handler_creation() {
         let handler = WasiAnteHandler::new();
         assert!(handler.is_ok());
-    }
-
-    #[test]
-    fn test_wasi_ante_handler_chain() {
-        let chain = WasiAnteHandlerChain::new();
-        assert_eq!(chain.handlers.len(), 0);
-    }
-
-    #[test]
-    fn test_tx_conversion() {
-        let handler = WasiAnteHandler::new().unwrap();
-        let tx = create_test_tx();
-
-        let wasi_tx = handler.convert_tx_to_wasi(&tx);
-        assert!(wasi_tx.is_ok());
-
-        let converted = wasi_tx.unwrap();
-        assert!(converted["body"]["messages"].is_array());
-        assert!(converted["auth_info"]["signer_infos"].is_array());
-    }
-
-    #[test]
-    fn test_context_conversion() {
-        let handler = WasiAnteHandler::new().unwrap();
-        let ctx = create_test_context();
-
-        let wasi_ctx = handler.convert_context_to_wasi(&ctx);
-        assert!(wasi_ctx.is_ok());
-
-        let converted = wasi_ctx.unwrap();
-        assert_eq!(converted["block_height"], 100);
-        assert_eq!(converted["chain_id"], "test-chain");
     }
 }

--- a/crates/helium-server/src/abci_server.rs
+++ b/crates/helium-server/src/abci_server.rs
@@ -789,7 +789,11 @@ mod tests {
         // Without a valid tx_decoder module, invalid transactions will fail
         // The test transaction [1, 2, 3, 4] is not a valid encoded transaction
         assert_eq!(result.code, 1);
-        assert!(result.log.contains("no messages") || result.log.contains("decode failed"));
+        assert!(
+            result.log.contains("no messages")
+                || result.log.contains("decode failed")
+                || result.log.contains("ante handler")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Resolved duplicate implementation between ante handler adapter and WASI module
- Cleaned up ante.rs to be a pure WASI adapter layer
- Integrated ante handler into transaction validation flow

## Changes Made

### 1. Refactored ante.rs
- Removed all duplicate validation logic
- Kept only minimal WASI adapter interface
- Removed duplicate types (gas consumption, chain creation, etc.)
- Now purely loads and executes the WASI module

### 2. BaseApp Integration
- Added ante handler to BaseApp struct
- Integrated ante handler into `check_tx` method
- Integrated ante handler into `deliver_tx` method
- Added ante handler module path to module configuration

### 3. Clean Separation of Concerns
- All validation logic now resides in `wasi-ante-handler` crate
- Adapter only contains communication types (AnteContext, WasiAnteResponse, etc.)
- No business logic duplication between adapter and WASI module

## Test Plan
- [x] All existing tests pass
- [x] Code builds successfully
- [x] Clippy and formatting checks pass
- [x] Ante handler is properly invoked in transaction flow

## Impact
This change ensures a clean microkernel architecture where the ante handler WASI module contains all validation logic, while the baseapp only contains a thin adapter layer for loading and executing the module.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated a WASI-based ante handler for transaction validation, enabling advanced and flexible transaction checks via a WASM module.

* **Refactor**
  * Simplified the ante handler logic to act as a thin adapter, delegating all transaction validation to the WASI module.
  * Removed local gas accounting and support for chaining multiple ante handlers.

* **Bug Fixes**
  * Updated test cases to handle new error outputs from the WASI ante handler integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->