### PR TITLE
Add writing style and tone guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,3 +225,44 @@ helium-baseapp (depends on all above)
 - Check similar code in the project for patterns
 - Prefer the approach used elsewhere in the codebase
 - If introducing a new pattern, apply it consistently across all affected files
+
+## Writing Style and Tone Guidelines
+
+When writing documentation, proposals, or technical explanations, maintain a neutral, professional tone that focuses on technical substance rather than dramatic language.
+
+### Language to Avoid
+
+**Avoid overly dramatic or hyperbolic language**:
+- "revolutionary" 
+- "fundamentally changes"
+- "groundbreaking"
+- "paradigm shift"
+- "transforms everything"
+- "game-changing"
+
+**Instead, use neutral, descriptive language**:
+- "introduces"
+- "enables"
+- "provides"
+- "implements"
+- "allows"
+- "supports"
+
+### Writing Principles
+
+**Keep it chill and neutral**:
+- Focus on technical facts and benefits
+- Avoid marketing-style language
+- Use precise, descriptive terms
+- Let the technical merit speak for itself
+
+**Be concise**:
+- Avoid unnecessary verbose explanations
+- Get to the point quickly
+- Use clear, direct language
+- Remove redundant phrasing
+
+**Stay technical**:
+- Emphasize implementation details over grand visions
+- Discuss concrete benefits rather than abstract concepts
+- Focus on how things work, not how amazing they are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,12 +257,14 @@ When writing documentation, proposals, or technical explanations, maintain a neu
 - Let the technical merit speak for itself
 
 **Be concise**:
-- Avoid unnecessary verbose explanations
 - Get to the point quickly
 - Use clear, direct language
 - Remove redundant phrasing
+- However be sure not to oversimplify
+
 
 **Stay technical**:
 - Emphasize implementation details over grand visions
 - Discuss concrete benefits rather than abstract concepts
 - Focus on how things work, not how amazing they are
+- Include all technical details and implicit context


### PR DESCRIPTION
Adds guidelines to prevent dramatic language like 'revolutionary' and 'fundamentally changes' in favor of neutral, technical language. Emphasizes keeping documentation chill and neutral while focusing on technical substance.

Addresses feedback from issue #59 about keeping proposals and documentation neutral and technical rather than dramatic.

Generated with [Claude Code](https://claude.ai/code)